### PR TITLE
Ignore cache files and files in bin other than the sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 .DS_Store
 **/.DS_Store
 .ignore
-bin/zspec
+bin/*
+!bin/zplug-env
 **/zcompdump
 **/*~
 **/*.swp
-test/_fixtures/.cache
+.cache


### PR DESCRIPTION
Hi, I noticed that there were some files that git doesn't ignore when I tried it out. I assumed that the cache file isn't something we want to version control so it's ignored no matter where it is.

Following is the commit message.

Note that this doesn't ignore the `repos` directory that it currently creates.
This is under the assumption that the directory structure will be changed to
what is described in:

https://github.com/b4b4r07/zplug/issues/71#issuecomment-171150415
