### PR TITLE
Fix compinit not found when loading

### DIFF
--- a/autoload/init.zsh
+++ b/autoload/init.zsh
@@ -22,6 +22,7 @@ fi
 
 autoload -Uz add-zsh-hook
 autoload -Uz colors; colors
+autoload -Uz compinit
 
 typeset -gx -A zplugs
 


### PR DESCRIPTION
I got the following error when starting zplug.

``` text
__load__:266: command not found: compinit
```
