### PR TITLE
Fix cache test failing after d71c575a

### DIFF
--- a/autoload/commands/__load__
+++ b/autoload/commands/__load__
@@ -38,6 +38,9 @@ done
 
 # Use cache file
 if __load_cache; then
+    if $is_debug; then
+        __put "$_ZPLUG_CACHE_FILE\n"
+    fi
     return 0
 fi
 


### PR DESCRIPTION
Really small change, but this should change the status to build passing.
