### PR TITLE
Fix tests failing on Gentoo

### DIFF
--- a/test/lib/job/spinner_test.zsh
+++ b/test/lib/job/spinner_test.zsh
@@ -3,6 +3,8 @@
 : before
 {
     source $ZPLUG_ROOT/lib/job/spinner.zsh
+    source $ZPLUG_ROOT/lib/print/print.zsh
+    source $ZPLUG_ROOT/autoload/init.zsh
     local -A zplugs
     local    expect actual
     local -i status_code


### PR DESCRIPTION
This is a workaround to fix #7. The reason why tests fail under certain
distros is because the order in which files are listed differs (i.e. are not
alphabetical under Gentoo Linux).
