### PR TITLE
Fix zplug.zsh not renamed to init.zsh

### DIFF
--- a/zplug
+++ b/zplug
@@ -20,7 +20,7 @@ EOLOGO
 # Check if current zsh is interactive
 if [[ $- =~ i ]]; then
     # source
-    zplug_main="${${(%):-%N}:A:h}/zplug.zsh"
+    zplug_main="${${(%):-%N}:A:h}/init.zsh"
     if [[ -f $zplug_main ]]; then
         source "$zplug_main"
     else


### PR DESCRIPTION
This fixes the bug introduced after fd4514b5e2b9ddbec8406b656a95ebe489dbaccb.
