### PR TITLE
Fix regex error

### DIFF
--- a/autoload/utils/__add__
+++ b/autoload/utils/__add__
@@ -36,7 +36,7 @@ fi
 if __zpluged; then
     for key in "${(k)zplugs[@]}"
     do
-        if [[ $key =~ ^$name@*$ ]] && (( $max < $#key )); then
+        if [[ $key =~ "^$name@*$" ]] && (( $max < $#key )); then
             max=$#key
             name="${key}@"
         fi


### PR DESCRIPTION
Error message:

```
__add__:39: failed to compile regex: Invalid preceding regular expression
```

This error is fixed by simply quoting the expression to prevent expansion.
