### PR TITLE
Fix clone failing when depth is 0

### DIFF
--- a/autoload/utils/__clone__
+++ b/autoload/utils/__clone__
@@ -28,6 +28,9 @@ do
             case $tag_depth in
                 0)
                     case "$ZPLUG_CLONE_DEPTH" in
+                        0)
+                            depth_option=""
+                            ;;
                         <->)
                             depth_option="--depth=$ZPLUG_CLONE_DEPTH"
                             ;;


### PR DESCRIPTION
Error message (from git, when removing the `&>/dev/null`) before this change is:

```
fatal: depth 0 is not a positive number
```
