### PR TITLE
Improve regex for detecting OMZ function dependencies

### DIFF
--- a/lib/support/omz.zsh
+++ b/lib/support/omz.zsh
@@ -33,7 +33,7 @@ __zplug::support::omz::depends() {
         do
             [[ -f $t ]] || continue
             sed '/^ *#/d' "$t" \
-                | grep "$lib_f" \
+                | egrep "(^|\s|['\"(\`])$lib_f($|\s|[\\\\'\")\`])"
                 &>/dev/null &&
                 depends+=( "$omz_libs[$lib_f]" )
         done


### PR DESCRIPTION
This change makes the pattern more strict so that expressions that are only in
valid function call forms are added as dependencies. Valid forms of function
use with examples are:
- `func`
  - `func`
- Leading or trailing whitespaces `func`
  - `func 'foo'`
- `func\`
  - Trailing backslash:
    
    ```
      func\
        'foo'
    ```
- `(func)`
  - `foo=$(func)`
- `"func"`
  - `eval "func"`
- `'func'`
  - `eval 'func'`
- Surrounded by backquotes
  
  ```
  `func`
  
  Example:
  foo=`func`
  ```
## Problem Description

Error message:

```
update_terminalapp_cwd:4: command not found: omz_urlencode
```

Is shown before every prompt when using Terminal.app on a Mac OS X.

This is because `lib/termsupport.zsh` is considered a dependency of `pip.plugin.zsh` and is therefore sourced, adding `update_terminalapp_cwd` function to the `precmd` hook.
## Environment
- Mac OS X 10.9.5 and 10.11.3
- Terminal.app bundled with the above versions
- zsh 5.2 and 5.0.8, respectively
- zplug 84bb580480bf6088fc025279d37c6ca41e1ffe39
### `.zshrc`

``` zsh
source $ZPLUG_HOME/init.zsh
zplug 'plugins/pip', \
    from:oh-my-zsh, \
    ignore:{oh-my-zsh.sh,plugins/pip/pip.plugin.zsh}, \
    nice:10

zplug check || zplug install
zplug load
```
## Steps to Reproduce
1. Start a new zsh session
2. Observe the message:
   
   ```
   update_terminalapp_cwd:4: command not found: omz_urlencode
   ```
## Why this happens

`plugins/pip/pip.plugin.zsh` has a `<title>` HTML tag [here](https://github.com/robbyrussell/oh-my-zsh/blob/8ac1859f377b5292597f11f5973bae1ebc8e2dce/plugins/pip/pip.plugin.zsh#L53). There is also a `title` function defined [here](https://github.com/robbyrussell/oh-my-zsh/blob/8ac1859f377b5292597f11f5973bae1ebc8e2dce/lib/termsupport.zsh#L9). Since zplug only checks the presence of the function name in `pip.plugin.zsh`, it thinks that the function is being used and sources `lib/termsupport.zsh`.

Apart from this issue, maybe the check for dependency (i.e. call to `__zplug::support::omz::depends`) need to be after excluding files specified by the `ignore` tag, but this is a different issue.
## What this PR fixes

In the example, it was `<title>` (an invalid form of function call) but from what I see it seems like `foo_title_bar` would also be considered a use of the `title` function. This PR fixes that scenario too. Valid function uses are described at the top and also in the commit message.
## Checking

``` console
$ cat <<EOF | egrep "(^|\s|['\"(\`])func[0-9]($|\s|[\\\\'\")\`])"
func1
<func2>
 func3
func4\\
  bar
eval 'func5'
eval "func6 foo"
\`func7\`
foo_func8_bar
EOF
# Outputs:
# func1
#  func3
# func4\
# eval 'func5'
# eval "func6 foo"
# `func7`
```
