### PR TITLE
Fix failure on loading init.zsh

### DIFF
--- a/zplug
+++ b/zplug
@@ -63,7 +63,7 @@ __get_zplug() {
 }
 
 function() {
-    local init_file="${${(%):-%N}:A:h}/init.zsh"
+    local init_file="${${(%):-%x}:A:h}/init.zsh"
 
     if [[ -z $ZSH_VERSION ]]; then
         printf "[zplug] zplug must be run on ZSH\n" >&2


### PR DESCRIPTION
`${${(%):-%N}:A:h}` will become the current directory in a function.
